### PR TITLE
Add bash alias to copy last commit hash

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -69,7 +69,18 @@ alias gs="git status"
 alias gd="git diff"
 alias gdc="git diff --cached"
 alias gpr="git pull --rebase"
-alias clc="git rev-parse HEAD | tr -d '\n' | pbcopy" # copy last commit
+
+copy_last_commit() {
+    local commit
+    commit=$(git rev-parse HEAD 2>/dev/null)
+    if [[ -z $commit ]]; then
+        echo "Not in a git repository"
+        return 1
+    fi
+    echo -n "$commit" | pbcopy
+    echo -n "$commit (copied to clipboard)"
+}
+alias clc=copy_last_commit
 
 
 # OS X uses different syntax for some commands :/

--- a/bashrc
+++ b/bashrc
@@ -69,6 +69,7 @@ alias gs="git status"
 alias gd="git diff"
 alias gdc="git diff --cached"
 alias gpr="git pull --rebase"
+alias clc="git rev-parse HEAD | tr -d '\n' | pbcopy" # copy last commit
 
 
 # OS X uses different syntax for some commands :/


### PR DESCRIPTION
This adds a script to copy the last (`HEAD`) commit to the clipboard and display some feedback. If not in a git directory then it prints as such and exits nonzero.