### PR TITLE
Cover more in ripgrep defaults

### DIFF
--- a/ripgreprc
+++ b/ripgreprc
@@ -6,6 +6,15 @@
 
 # Filter out certain generated & compiled files
 --glob=!yarn.lock
+--glob=!package-lock.json
 --glob=!composer.lock
 --glob=!*.js.map
 --glob=!phpstan-baseline.neon
+
+# And SVGs
+--glob=!*.svg
+
+# Include hidden
+--hidden
+# But still keep out .git
+--glob=!.git/*


### PR DESCRIPTION
- Filter out more package manager lockfiles
- Filter out SVGs
- Do NOT filter out dotfiles, but continue to filter out .git (goal: include `.github/*` etc in searches)