### PR TITLE
Set other homebrew auto-update flag

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -32,6 +32,7 @@ export EDITOR=vim
 
 # Homebrew
 export HOMEBREW_NO_AUTO_UPGRADE=1
+export HOMEBREW_NO_INSTALL_UPGRADE=1
 export HOMEBREW_NO_ANALYTICS=1
 # Set PATH, MANPATH, etc., for Homebrew.
 eval "$(/opt/homebrew/bin/brew shellenv)"


### PR DESCRIPTION
This is probably more merge conflict resolution than anything else, but it sets an additional flag to prevent `brew`'s behavior of aggressively updating packages.