### PR TITLE
Set up 'test' type for ripgrep

### DIFF
--- a/ripgreprc
+++ b/ripgreprc
@@ -18,3 +18,8 @@
 --hidden
 # But still keep out .git
 --glob=!.git/*
+
+# Create a "test" type for common test files, typically for use with -t/-T
+--type-add=test:*.test.*
+--type-add=test:*Test.*
+--type-add=test:*Tests.*


### PR DESCRIPTION
I frequently want to filter (out) test cases from my search results. This defines some common glob patterns for `test` [file type](https://github.com/BurntSushi/ripgrep/blob/de4baa10024f2cb62d438596274b9b710e01c59b/GUIDE.md#manual-filtering-file-types), which allows searching only (`-ttest`) or excluding (`-Ttest`) files matching these patterns. This works for polyglot codebases as well, e.g. `rg -tphp -Ttest searchterm` should match only non-test php files.